### PR TITLE
fix: error for argument of wrong type should be a TypeError

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -10,6 +10,12 @@
  * convert(`"That's a 'magic' shoe."`); // “That’s a ‘magic’ shoe.”
  */
 export function convert(text: string): string {
+  // If a string was not provided then it should also not be returned, nor
+  // should the function fail silently.
+  if (typeof text !== 'string') {
+    throw new TypeError('quote-quote: "convert()" argument must be a string');
+  }
+
   return (
     text
       // Quadruple and triple prime.

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, test } from '@jest/globals';
 import { convert } from '../src/convert';
 
+describe('API', () => {
+  test.each([undefined, null, false, 0, true, 1, [], {}])(
+    'throws an error when its argument is %s',
+    (argument) => {
+      expect(() => convert(argument as string)).toThrow(
+        'quote-quote: "convert()" argument must be a string',
+      );
+    },
+  );
+
+  test('does not throw an error when its argument is an empty string', () => {
+    expect(() => convert('')).not.toThrowError();
+  });
+
+  test('returns a string', () => {
+    expect(convert('')).toEqual('');
+    expect(convert('foo')).toEqual('foo');
+  });
+});
+
 describe('Basic scenarios', () => {
   describe('Single quotes', () => {
     test.each([


### PR DESCRIPTION
The error for not providing `convert()` with a `String` should be more descriptive, and of `TypeError`.