### PR TITLE
feat: add package.json entry point to the exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
     "node": ">=16.0.0"
   },
   "exports": {
-    "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Allows for importing the `package.json`.

Example using Import Attributes:

```js
import pkg from 'quote-quote/package.json' with { type: 'json' };
```

Or with Import Assertions on older Node.js versions (because this library supports Node.js 16):

```js
import pkg from 'quote-quote/package.json' assert { type: 'json' };
```